### PR TITLE
Add backend tests and coverage config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
-# upload-docs
-uploading documents
+# Document Processing Application
+
+This repository contains a proof‑of‑concept for uploading documents, extracting text with Apache Tika and storing results in PostgreSQL. The project consists of a React frontend and an Express/TypeScript backend.
+
+## Repository Layout
+
+- `backend/` – Express API handling uploads and persisting data
+- `frontend/` – React application (Create React App)
+- `docker-compose.yml` – Development stack including Postgres and Apache Tika
+- `docs/` – Design documents and plans
+
+## Running Locally with Docker Compose
+
+Ensure Docker and Docker Compose are installed. From the project root run:
+
+```bash
+docker-compose up --build
+```
+
+The backend will be available at `http://localhost:3001` and the frontend at `http://localhost:3000`.
+
+## Running Tests
+
+Unit and integration tests are implemented with [Jest](https://jestjs.io/).
+Run tests from the project root using:
+
+```bash
+npm test --prefix backend
+```
+
+Coverage reports are generated automatically and a global threshold of 80% is
+enforced.
+
+## Development Plan
+
+The next steps for completing the application are outlined in [docs/phase2_plan.md](docs/phase2_plan.md). This includes adding an upload form, containerizing the frontend, implementing tests and setting up CI with GitHub Actions.
+
+## License
+
+This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE) for details.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --coverage",
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts"
@@ -26,6 +26,11 @@
     "@types/pg": "^8.15.2",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/jest": "^29.5.8",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/src/__tests__/db.test.ts
+++ b/backend/src/__tests__/db.test.ts
@@ -1,0 +1,49 @@
+import { insertDocument, updateDocumentStatusAndText, getDocumentById } from '../db';
+import { Pool } from 'pg';
+
+jest.mock('pg', () => {
+  const mQuery = jest.fn();
+  const mClient = { query: mQuery, release: jest.fn() };
+  const mPool = {
+    connect: jest.fn().mockResolvedValue(mClient),
+    query: mQuery,
+    on: jest.fn(),
+  };
+  return { Pool: jest.fn(() => mPool) };
+});
+
+describe('database helpers', () => {
+  const pool = new Pool() as any;
+  beforeEach(() => {
+    (pool.query as jest.Mock).mockReset();
+  });
+
+  test('insertDocument stores metadata and returns id', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [{ id: 123 }] });
+    const id = await insertDocument('f', 'o', 'text/plain', 10);
+    expect(pool.query).toHaveBeenCalledWith(
+      'INSERT INTO documents (filename, originalname, mimetype, size, status) VALUES ($1, $2, $3, $4, $5) RETURNING id',
+      ['f', 'o', 'text/plain', 10, 'processing']
+    );
+    expect(id).toBe(123);
+  });
+
+  test('updateDocumentStatusAndText updates status and text', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({});
+    await updateDocumentStatusAndText(1, 'completed', 'text');
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE documents SET status = $1, extracted_text = $2, processing_timestamp = CURRENT_TIMESTAMP WHERE id = $3',
+      ['completed', 'text', 1]
+    );
+  });
+
+  test('getDocumentById returns single row', async () => {
+    (pool.query as jest.Mock).mockResolvedValue({ rows: [{ id: 1 }] });
+    const row = await getDocumentById(1);
+    expect(pool.query).toHaveBeenCalledWith(
+      'SELECT id, filename, originalname, mimetype, size, status, extracted_text, upload_timestamp, processing_timestamp FROM documents WHERE id = $1',
+      [1]
+    );
+    expect(row).toEqual({ id: 1 });
+  });
+});

--- a/backend/src/__tests__/index.test.ts
+++ b/backend/src/__tests__/index.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+import { app } from '../index';
+import * as db from '../db';
+import axios from 'axios';
+
+jest.mock('../db');
+jest.mock('axios');
+
+describe('express routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('root responds', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/running/i);
+  });
+
+  test('GET /api/document/:id validates id', async () => {
+    const res = await request(app).get('/api/document/abc');
+    expect(res.status).toBe(400);
+  });
+
+  test('GET /api/document/:id returns 404 when missing', async () => {
+    (db.getDocumentById as jest.Mock).mockResolvedValue(undefined);
+    const res = await request(app).get('/api/document/1');
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /api/document/:id returns document', async () => {
+    (db.getDocumentById as jest.Mock).mockResolvedValue({ id: 1, status: 'completed' });
+    const res = await request(app).get('/api/document/1');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(1);
+  });
+
+  test('GET /api/document/:id/status returns status', async () => {
+    (db.getDocumentById as jest.Mock).mockResolvedValue({ id: 1, status: 'pending' });
+    const res = await request(app).get('/api/document/1/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: 1, status: 'pending' });
+  });
+
+  test('POST /api/upload without file', async () => {
+    const res = await request(app).post('/api/upload');
+    expect(res.status).toBe(400);
+  });
+
+  test('POST /api/upload success path', async () => {
+    (db.insertDocument as jest.Mock).mockResolvedValue(1);
+    (axios.post as jest.Mock).mockResolvedValue({ data: 'text' });
+    const res = await request(app)
+      .post('/api/upload')
+      .attach('document', Buffer.from('hello'), 'hello.txt');
+    expect(res.status).toBe(200);
+    expect(db.insertDocument).toHaveBeenCalled();
+    expect(db.updateDocumentStatusAndText).toHaveBeenCalledWith(1, 'completed', 'text');
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,7 +7,7 @@ import FormData from 'form-data';
 import { initializeDatabase, insertDocument, updateDocumentStatusAndText, getDocumentById } from './db';
 
 // Initialize Express application
-const app = express();
+export const app = express();
 // Define the port for the server, fallback to 3001 if not specified in environment
 const port = process.env.PORT || 3001;
 // Define the URL for the Tika service, fallback to local Docker service if not specified
@@ -176,7 +176,7 @@ app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
 
 // Asynchronous function to start the server.
 // This ensures that database initialization is complete before the server starts listening for requests.
-const startServer = async () => {
+export const startServer = async () => {
   try {
     await initializeDatabase(); // Initialize database connection and tables
     app.listen(port, () => {
@@ -188,5 +188,7 @@ const startServer = async () => {
   }
 };
 
-// Start the server
-startServer();
+// Start the server unless running in a test environment
+if (process.env.NODE_ENV !== 'test') {
+  startServer();
+}

--- a/docs/phase2_plan.md
+++ b/docs/phase2_plan.md
@@ -1,0 +1,57 @@
+# Next Phase Development Plan
+
+This document outlines the remaining steps to deliver the full document processing application. The goal is a containerized stack that allows users to upload documents via a React UI, extracts text using Apache Tika, stores data in PostgreSQL and runs tests via GitHub Actions.
+
+## Overview of Current State
+
+- **Backend**: Express + TypeScript service capable of accepting uploads and forwarding them to Apache Tika. The code persists documents and extracted text to PostgreSQL.
+- **Frontend**: React application generated with Create React App. Currently minimal with no upload form.
+- **Docker Compose**: Defines services for backend, frontend, Postgres and Tika. Backend container already has a Dockerfile. Frontend container image is not defined yet.
+- **Testing**: No automated tests or CI configured.
+
+## Objectives for Phase 2
+
+1. **Frontend Upload UI**
+   - Add a simple form allowing users to select a file and POST it to `/api/upload`.
+   - Show upload progress and display the extracted text once processing completes.
+   - Handle errors such as invalid file types or server failures.
+
+2. **Backend Enhancements**
+   - Replace plain `console.log` statements with a structured logging library (e.g. `winston`).
+   - Add validation around uploads (limit file size, enforce required field `document`).
+   - Provide an endpoint for listing all uploaded documents and their status.
+
+3. **Docker and Kubernetes**
+   - Create a `frontend/Dockerfile` and update `docker-compose.yml` to build and run the React application in a container.
+   - Prepare Kubernetes manifests (Deployment, Service, Ingress) for backend and frontend for future deployment.
+
+4. **Testing Strategy**
+   - Use **Jest** for unit tests in the backend (DB functions, route handlers) and integration tests against a running test database.
+   - Use **Playwright** for end‑to‑end tests covering the upload flow in the UI.
+   - Configure `package.json` scripts in both projects to run these tests.
+   - Aim for at least **80%** code coverage verified via Jest's coverage reports.
+   - Add GitHub Actions workflow to install dependencies, run lint, and execute Jest and Playwright suites on every pull request.
+
+5. **Documentation**
+   - Expand the root `README.md` with setup instructions, environment variables and local development workflow.
+   - Document how to run the stack via Docker Compose and where to access each service.
+   - Provide a short guide on deploying to Kubernetes using the manifests from step 3.
+
+## Recommended File Layout
+
+```
+/docs                Project documentation
+/frontend            React application
+/backend             Express API
+/k8s                 Kubernetes manifests
+```
+
+## Milestones
+
+1. Build the upload form in the React app and verify manual file uploads work against the running backend.
+2. Introduce structured logging and an additional API endpoint for listing documents.
+3. Containerize the frontend and confirm the Docker Compose stack works end‑to‑end.
+4. Add automated Jest and Playwright tests. Verify GitHub Actions runs them on push.
+5. Create Kubernetes manifests and document deployment steps.
+
+Completion of these tasks will deliver a functional, testable, containerized application ready for enterprise deployment.


### PR DESCRIPTION
## Summary
- document how to run tests with Jest in the README
- enforce 80% coverage in docs and Jest config
- export the Express app for testing
- add Jest configuration and mock-based unit/integration tests for backend

## Testing
- `npm test --silent --prefix backend` *(fails: jest: not found)*
- `npm test --silent --prefix frontend` *(fails: react-scripts: not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.