### PR TITLE
Add logger usage and docs endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -76,6 +76,10 @@ Here are the primary API endpoints:
     - Replace `:id` with the document's ID.
     - Example: `curl http://localhost:3001/api/document/1/status`
 
+- **`GET /api/documents`**:
+    - Returns a list of all uploaded documents and their metadata.
+    - Example: `curl http://localhost:3001/api/documents`
+
 ## Project Structure
 
 - `src/`: Contains the TypeScript source code.

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,9 +1,10 @@
 import { Pool } from 'pg';
+import logger from './util/logger';
 
 // Ensure DATABASE_URL is set, otherwise the application cannot function.
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
-  console.error('FATAL: DATABASE_URL environment variable is not set.');
+  logger.error('FATAL: DATABASE_URL environment variable is not set.');
   process.exit(1); // Exit if DB URL is not found, as it's critical
 }
 
@@ -19,12 +20,12 @@ const pool = new Pool({
 
 // Event listener for new client connections.
 pool.on('connect', () => {
-  console.log('Connected to PostgreSQL database!');
+  logger.info('Connected to PostgreSQL database!');
 });
 
 // Event listener for errors that occur on idle clients.
 pool.on('error', (err) => {
-  console.error('Unexpected error on idle client', err);
+  logger.error(`Unexpected error on idle client: ${err}`);
   process.exit(-1); // Exit on pool errors to prevent undefined behavior
 });
 
@@ -38,7 +39,7 @@ export const initializeDatabase = async () => {
   try {
     // Test query to ensure connection is working
     await client.query('SELECT NOW()');
-    console.log('Database connection test successful.');
+    logger.info('Database connection test successful.');
 
     // SQL to create the 'documents' table if it doesn't already exist.
     // This table stores metadata and extracted text for uploaded documents.
@@ -56,10 +57,10 @@ export const initializeDatabase = async () => {
       );
     `;
     await client.query(createTableQuery);
-    console.log('Table "documents" checked/created successfully.');
+    logger.info('Table "documents" checked/created successfully.');
 
   } catch (err) {
-    console.error('Error initializing database or creating table:', err);
+    logger.error(`Error initializing database or creating table: ${err}`);
     throw err; // Re-throw to be caught by application startup logic
   } finally {
     client.release(); // Release the client back to the pool

--- a/backend/tests/routes.test.ts
+++ b/backend/tests/routes.test.ts
@@ -6,7 +6,7 @@ jest.mock('../src/db', () => ({
   insertDocument: jest.fn(),
   updateDocumentStatusAndText: jest.fn(),
   initializeDatabase: jest.fn(),
-  listDocuments: jest.fn().mockResolvedValue([])
+  listDocuments: jest.fn().mockResolvedValue([{ id: 1, originalname: 'file.txt' }])
 }));
 
 describe('GET /api/document/:id', () => {
@@ -19,5 +19,14 @@ describe('GET /api/document/:id', () => {
     const res = await request(app).get('/api/document/1');
     expect(res.status).toBe(200);
     expect(res.body.id).toBe(1);
+  });
+});
+
+describe('GET /api/documents', () => {
+  it('returns list of documents', async () => {
+    const res = await request(app).get('/api/documents');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- wire DB utilities up to new logger
- update API docs with `/api/documents`
- test listing documents via new endpoint

## Testing
- `npm test --prefix backend` *(fails: jest not found)*