### PR TITLE
Setup tests for both packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "work", "master"]
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+      - run: npm test
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[tj]s'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts"
@@ -21,10 +21,15 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.2",
+    "@types/jest": "^29.5.11",
     "@types/multer": "^1.4.12",
     "@types/node": "^22.15.21",
     "@types/pg": "^8.15.2",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.7.0",
     "nodemon": "^3.1.10",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import { app } from './index';
+
+describe('app', () => {
+  it('responds to GET / with running message', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Backend server is running');
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,7 +7,7 @@ import FormData from 'form-data';
 import { initializeDatabase, insertDocument, updateDocumentStatusAndText, getDocumentById } from './db';
 
 // Initialize Express application
-const app = express();
+export const app = express();
 // Define the port for the server, fallback to 3001 if not specified in environment
 const port = process.env.PORT || 3001;
 // Define the URL for the Tika service, fallback to local Docker service if not specified
@@ -176,7 +176,7 @@ app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
 
 // Asynchronous function to start the server.
 // This ensures that database initialization is complete before the server starts listening for requests.
-const startServer = async () => {
+export const startServer = async () => {
   try {
     await initializeDatabase(); // Initialize database connection and tables
     app.listen(port, () => {
@@ -188,5 +188,7 @@ const startServer = async () => {
   }
 };
 
-// Start the server
-startServer();
+// Start the server if this file is run directly
+if (require.main === module) {
+  startServer();
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,11 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/frontend/tests/example.spec.ts
+++ b/frontend/tests/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has title', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/react/i);
+});


### PR DESCRIPTION
## Summary
- add Jest config to backend for unit/integration tests
- expose the Express app for testing
- add a simple root endpoint test
- configure Playwright for frontend UI tests
- add CI workflow to run backend Jest tests and frontend Playwright tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*